### PR TITLE
Fix annotation bugs/Generalise generation of object param dictionary

### DIFF
--- a/Blender/blender_automation/src/BlenderAPI/BlenderScene.py
+++ b/Blender/blender_automation/src/BlenderAPI/BlenderScene.py
@@ -258,5 +258,5 @@ class BlenderScene(object):
                         if _x < min_x: min_x = _x
                         if _y > max_y: max_y = _y
                         if _y < min_y: min_y = _y
-            annotation[obj.name] = [(round(min_x), round(max_y)), (round(max_x),round(min_y))]
+            annotation[obj.name] = [obj.parent, (round(min_x), round(max_y)), (round(max_x),round(min_y))]
         return annotation

--- a/Blender/blender_automation/src/object_dict_generator.py
+++ b/Blender/blender_automation/src/object_dict_generator.py
@@ -22,8 +22,8 @@ import json
 from math import pi
 
 file_location = os.path.dirname(__file__)
-head, tail = os.path.split(file_location)
-base_path = os.path.join(head, 'workspace', 'objects')
+abs_path = os.path.abspath(file_location)
+base_path = os.path.abspath(os.path.join(abs_path, os.pardir, 'workspace', 'objects'))
 
 #Individual object parameters
 wine = {

--- a/Blender/blender_automation/src/render_poses.py
+++ b/Blender/blender_automation/src/render_poses.py
@@ -17,10 +17,16 @@ sys.path.append(os.path.dirname(MODULE_DIRECTORY))
 
 # To import python packages like pandas
 #TODO generalize this path
-#sys.path.append('/home/solus/anaconda3/lib/python3.8/site-packages')
-sys.path.append(r"C:\Users\nickh\anaconda3\Lib\site-packages")
-sys.path.append(os.getcwd())
-##TODO : [utils.delete_all] not being used, anyway it's written in BlenderScene Class as Class Method
+try: # bad hack just for the time being so that 
+    we don't have to change it everytime we ran on each of our system
+    sys.path.append('/home/solus/anaconda3/lib/python3.8/site-packages')
+except:
+    sys.path.append(r"C:\Users\nickh\anaconda3\Lib\site-packages")
+
+## TODO: Don't need anymore, intended for the import of utils.py which we aren't using anymore
+# sys.path.append(os.getcwd())
+
+#TODO : [utils.delete_all] not being used, anyway it's written in BlenderScene Class as Class Method
 #from utils import delete_all
 
 from RenderInterface import RenderInterface

--- a/Blender/blender_automation/src/render_poses.py
+++ b/Blender/blender_automation/src/render_poses.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.dirname(MODULE_DIRECTORY))
 # To import python packages like pandas
 #TODO generalize this path
 try: # bad hack just for the time being so that 
-    we don't have to change it everytime we ran on each of our system
+    #we don't have to change it everytime we ran on each of our system
     sys.path.append('/home/solus/anaconda3/lib/python3.8/site-packages')
 except:
     sys.path.append(r"C:\Users\nickh\anaconda3\Lib\site-packages")
@@ -35,18 +35,19 @@ start = time()
 
 # Open a file for writing object annotations
 write_annotation = open('annotations.csv', 'w')
+write_annotation.write('file_path\tobject_name\ttop_left_xy\tright_bottom_xy\n')
 
 # Creating a RenderInterface which would be doing all the importing and
 # placement of the objects, along with the scene/rendering setup
 RI = RenderInterface(resolution=(400,600), samples=128, set_high_quality=True)
 
 
-for i in range(60):
+for i in range(1):
   RI.scene.delete_all()
   RI.setup_blender(resolution=(400,600), samples=128, set_high_quality=True)
   RI.place_all(repeat_objects=True)
 
-  imgs_per_shuffle = 10
+  imgs_per_shuffle = 1
   for j in range(imgs_per_shuffle):
     single_img_time = time()
     RI.shuffle_objects()
@@ -63,10 +64,11 @@ for i in range(60):
     annotation = RI.scene.get_annotation()
     #TODO could be written directly in COCO format
     for ann in annotation:
-    	left_top = annotation[ann]
-    	right_bottom = annotation[ann]
+        object_name = annotation[ann][0]
+        left_top = annotation[ann][1]
+        right_bottom = annotation[ann][2]
       #TODO import params JSON file and convert 3d model object name to the actual label, Could be part of post annotation processing seperately
-    	write_annotation.write(f'{file_path},{ann},{left_top[0]},{left_top[1]},{right_bottom[0]},{right_bottom[1]}\n')
+        write_annotation.write(f'{file_path}\t{object_name}\t({left_top[0]},{left_top[1]})\t({right_bottom[0]},{right_bottom[1]})\n')
 
 end = time()
 print(f'\n\n\n:: Total time elapsed in rendering and replacements: {end-start}')

--- a/Blender/blender_automation/src/render_poses.py
+++ b/Blender/blender_automation/src/render_poses.py
@@ -34,7 +34,7 @@ from RenderInterface import RenderInterface
 start = time()
 
 # Open a file for writing object annotations
-write_annotation = open('annotations.csv', 'w')
+write_annotation = open('annotations.tsv', 'w')
 write_annotation.write('file_path\tobject_name\ttop_left_xy\tright_bottom_xy\n')
 
 # Creating a RenderInterface which would be doing all the importing and


### PR DESCRIPTION
- Generalize generation of object dictionary using os.path.abspath() in the generation python script
- changed the annotation format from csv to tsv
- fixed object names in final annotation file

earlier:
<img width="1142" alt="Screenshot 2020-11-05 at 7 49 00 PM" src="https://user-images.githubusercontent.com/43279204/98252450-f83de880-1f9f-11eb-9eef-081a89be039c.png">
and the annotation have the file path as .jpg
<img width="1142" alt="Screenshot 2020-11-05 at 7 49 42 PM" src="https://user-images.githubusercontent.com/43279204/98252595-23283c80-1fa0-11eb-9291-2020c9ac22ac.png">


And that pattern to store the annotation of storing the all four points is also unnecessary, as any use case would only require two opposite point of the rectangle.